### PR TITLE
Allow build failure propogation

### DIFF
--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -23,7 +23,7 @@ init_python_modules_in lib
 init_python_modules_in test
 
 # Compute coverage
-( cd ${SCRIPT_CURRENT_DIR} && PYTHONPATH=lib coverage run --source "lib/solutions" -m pytest -s test 1>&2 )
+( cd ${SCRIPT_CURRENT_DIR} && PYTHONPATH=lib coverage run --source "lib/solutions" -m pytest -s test || true 1>&2 )
 ( cd ${SCRIPT_CURRENT_DIR} && coverage xml 1>&2 )
 
 [ -e ${PYTHON_CODE_COVERAGE_INFO} ] && rm ${PYTHON_CODE_COVERAGE_INFO}

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -23,15 +23,16 @@ init_python_modules_in lib
 init_python_modules_in test
 
 # Compute coverage
-( cd ${SCRIPT_CURRENT_DIR} && PYTHONPATH=lib coverage run --source "lib/solutions" -m pytest -s test || true 1>&2 )
-( cd ${SCRIPT_CURRENT_DIR} && coverage xml || true 1>&2 )
+( cd ${SCRIPT_CURRENT_DIR} && PYTHONPATH=lib coverage run --source "lib/solutions" -m pytest -s test 1>&2 )
+( cd ${SCRIPT_CURRENT_DIR} && coverage xml 1>&2 )
 
 [ -e ${PYTHON_CODE_COVERAGE_INFO} ] && rm ${PYTHON_CODE_COVERAGE_INFO}
 
 # Extract coverage percentage for target challenge
 if [ -f "${COVERAGE_TEST_REPORT_XML_FILE}" ]; then
-    COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="lib.solutions.'${CHALLENGE_ID}'"]/@line-rate' ${COVERAGE_TEST_REPORT_XML_FILE} || true)
     PERCENTAGE=$(( 0 ))
+    echo ${PERCENTAGE} > ${PYTHON_CODE_COVERAGE_INFO}
+    COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="lib.solutions.'${CHALLENGE_ID}'"]/@line-rate' ${COVERAGE_TEST_REPORT_XML_FILE})
     if [[ ! -z "${COVERAGE_OUTPUT}" ]]; then
         PERCENTAGE=$(echo ${COVERAGE_OUTPUT} | cut -d "\"" -f 2 | awk '{printf "%.0f",$1 * 100}' )
     fi


### PR DESCRIPTION
It's tricky to remove all the `|| true` from python, even with 100 code coverage, the runner can return a non-zero exit code if there are one or more failing tests

Related to https://github.com/julianghionoiu/dpnt-coverage/pull/34