### PR TITLE
Upgrade from Python 2.x to 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,6 @@
 - `Python 3.7` (note: support for `Python 2.x` has been dropped)
 - `pip` (ensure it supports `Python 3.7`)
 
-### Tip
-
-Updating `python`
-
-**via conda**
-
-`$ conda install python=3.7`
-
-Updating `pip`
-
-**via pip**
-
-`$ pip install --upgrade pip`
-
-**via CLI (optional)**
-
-```
-$ wget https://bootstrap.pypa.io/get-pip.py
-$ python3.7 get-pip.py
-```
-
-`python 3.7` can be referenced as `python`, `python3` or `python3.7`. Similarly, `pip` under `python 3.7` can be referenced as `pip`, `pip3` or `pip3.7`. 
 
 ## 2. How to start
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,31 @@
 
 ## 1. Requirements
 
-- `Python 2.7`
-- `pip`
+- `Python 3.7` (note: support for `Python 2.x` has been dropped)
+- `pip` (ensure it supports `Python 3.7`)
+
+### Tip
+
+Updating `python`
+
+**via conda**
+
+`$ conda install python=3.7`
+
+Updating `pip`
+
+**via pip**
+
+`$ pip install --upgrade pip`
+
+**via CLI (optional)**
+
+```
+$ wget https://bootstrap.pypa.io/get-pip.py
+$ python3.7 get-pip.py
+```
+
+`python 3.7` can be referenced as `python`, `python3` or `python3.7`. Similarly, `pip` under `python 3.7` can be referenced as `pip`, `pip3` or `pip3.7`. 
 
 ## 2. How to start
 

--- a/lib/runner/user_input_action.py
+++ b/lib/runner/user_input_action.py
@@ -1,2 +1,2 @@
 def get_user_input(args):
-    return args[0] if len(args) > 0 else input()
+    return args[0] if len(args) > 0 else str(input("> "))

--- a/lib/runner/user_input_action.py
+++ b/lib/runner/user_input_action.py
@@ -1,2 +1,2 @@
 def get_user_input(args):
-    return args[0] if len(args) > 0 else raw_input()
+    return args[0] if len(args) > 0 else input()

--- a/lib/runner/utils.py
+++ b/lib/runner/utils.py
@@ -1,6 +1,6 @@
 from tdl.runner.challenge_session_config import ChallengeSessionConfig
 from tdl.queue.implementation_runner_config import ImplementationRunnerConfig
-from credentials_config_file import read_from_config_file, read_from_config_file_with_default
+from .credentials_config_file import read_from_config_file, read_from_config_file_with_default
 
 import os
 

--- a/lib/send_command_to_server.py
+++ b/lib/send_command_to_server.py
@@ -1,12 +1,12 @@
 import sys
 from tdl.queue.queue_based_implementation_runner import QueueBasedImplementationRunnerBuilder
 from tdl.runner.challenge_session import ChallengeSession
-from solutions.SUM import sum_solution
-from solutions.HLO import hello_solution
-from solutions.FIZ import fizz_buzz_solution
-from solutions.CHK import checkout_solution
-from runner.utils import Utils
-from runner.user_input_action import get_user_input
+from .solutions.SUM import sum_solution
+from .solutions.HLO import hello_solution
+from .solutions.FIZ import fizz_buzz_solution
+from .solutions.CHK import checkout_solution
+from .runner.utils import Utils
+from .runner.user_input_action import get_user_input
 
 
 """

--- a/lib/send_command_to_server.py
+++ b/lib/send_command_to_server.py
@@ -1,12 +1,12 @@
 import sys
 from tdl.queue.queue_based_implementation_runner import QueueBasedImplementationRunnerBuilder
 from tdl.runner.challenge_session import ChallengeSession
-from .solutions.SUM import sum_solution
-from .solutions.HLO import hello_solution
-from .solutions.FIZ import fizz_buzz_solution
-from .solutions.CHK import checkout_solution
-from .runner.utils import Utils
-from .runner.user_input_action import get_user_input
+from solutions.SUM import sum_solution
+from solutions.HLO import hello_solution
+from solutions.FIZ import fizz_buzz_solution
+from solutions.CHK import checkout_solution
+from runner.utils import Utils
+from runner.user_input_action import get_user_input
 
 
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tdl-client-python==0.25.0
+tdl-client-python==0.26.0 ## will need to be corrected once a new version number is known
 coverage==4.5.1
 pytest==2.9.1
 pytest-cov==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tdl-client-python==0.26.0 ## will need to be corrected once a new version number is known
+tdl-client-python==0.26.0
 coverage==4.5.1
 pytest==2.9.1
 pytest-cov==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tdl-client-python==0.26.0
+tdl-client-python==0.26.1
 coverage==4.5.1
 pytest==2.9.1
 pytest-cov==2.1.0


### PR DESCRIPTION
Converted all .py files from python 2.x to 3.7. Also added instructions in the README

Fixes #7 

Merging of this PR is dependent on merging of https://github.com/julianghionoiu/tdl-client-python/pull/19 and updating the tdl-client-python package version number in the requirements.txt file